### PR TITLE
Fix for Android 4.4.4

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,7 @@ module.exports =  {
                     transferable.push(args[i]);
 
                 // tranferable: ImageData
-                } else if (args[i] instanceof ImageData) {
+                } else if ("ImageData" in global && args[i] instanceof ImageData) {
                     transferable.push(args[i].data.buffer);
 
                 // tranferable: TypedArray


### PR DESCRIPTION
Hey, great module! I noticed that in the stock Android 4.4.4 browser, the `instanceof ImageData` check causes exceptions to be thrown, so this change will fix that and allow all your tests to pass.